### PR TITLE
Integrate Telegram module with interactive bot app

### DIFF
--- a/telegram/README.md
+++ b/telegram/README.md
@@ -45,6 +45,35 @@ COMAN_TG_DEFAULT_LANG=ru
 The runner will reuse the FastAPI client utilities defined in the core package
 so the bot can query the HTTP API for integration data.
 
+## Example prompts and flows
+
+Once the bot is running you can message it directly in Telegram. The commands
+and inline buttons exposed by the handlers cover the following common flows:
+
+* **Show the main menu:** send `/start` to register the user, reset any pending
+  flows, and display the interactive menu with actions such as “Get data”,
+  “Send data”, “System status”, “About”, “Settings”, and optionally “Admin
+  Panel” for privileged users.
+* **Get the current status:** tap the “System status” button or send `/status`
+  to trigger the status handler. The bot fetches the latest health and info data
+  from the Coman API and returns a formatted summary.
+* **Submit text for processing:** choose “Send data” from the menu. The bot will
+  prompt you with “Type the text you want to send:” and wait for your next
+  message. Reply with the payload you want to forward to the Coman API; the bot
+  echoes either a success confirmation or the error returned by the service.
+* **Retrieve information:** pick “Get data” to ask the API for the structured
+  info payload and display it in chat using bullet points.
+* **Adjust language:** open “Settings” and select either “Русский” or
+  “English”. The preference is stored per user and subsequent prompts adopt the
+  chosen language.
+* **Reach the admin panel:** if the user ID matches the configured admin list or
+  a stored admin role, pressing “Admin Panel” shows the dedicated welcome text
+  and can be extended with privileged actions.
+
+These prompts mirror the logic implemented in
+`telegram/coman/modules/telegram_module/handlers.py`, so they stay in sync with
+the shipped bot behaviour.
+
 ## Docker usage
 
 ```bash

--- a/telegram/coman/modules/telegram_module/bot.py
+++ b/telegram/coman/modules/telegram_module/bot.py
@@ -3,15 +3,17 @@ from telegram.ext import (
     ApplicationBuilder, CommandHandler, CallbackQueryHandler,
     MessageHandler, filters
 )
-from .config import load_config
+from typing import Optional
+
+from .config import Config, load_config
 from .db import DB
 from .api import ComanAPI
 from .handlers import cmd_start, cmd_status, cb_menu, cb_settings, on_text
 
 log = logging.getLogger("coman.telegram")
 
-def build_application():
-    cfg = load_config()
+def build_application(cfg: Optional[Config] = None):
+    cfg = cfg or load_config()
     db = DB(cfg.db_path, cfg.default_lang)
     api = ComanAPI(cfg.api_base_url, cfg.api_token, cfg.request_timeout_s)
 

--- a/telegram/ext/__init__.py
+++ b/telegram/ext/__init__.py
@@ -64,12 +64,24 @@ class ApplicationBuilder:
         return self._factory()
 
 
-class MessageHandler:
+class _BaseHandler:
     """Container that stores handler configuration for tests."""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         self.args = args
         self.kwargs = kwargs
+
+
+class MessageHandler(_BaseHandler):
+    pass
+
+
+class CommandHandler(_BaseHandler):
+    pass
+
+
+class CallbackQueryHandler(_BaseHandler):
+    pass
 
 
 class _Filter:
@@ -91,6 +103,8 @@ filters = _FiltersModule()
 __all__ = [
     "Application",
     "ApplicationBuilder",
+    "CallbackQueryHandler",
+    "CommandHandler",
     "ContextTypes",
     "MessageHandler",
     "filters",

--- a/tests/test_module_runner.py
+++ b/tests/test_module_runner.py
@@ -7,10 +7,10 @@ from types import ModuleType
 
 
 class _DummyFilter:
-    def __and__(self, _other):
+    def __and__(self, _other):  # pragma: no cover - trivial stub
         return self
 
-    def __invert__(self):
+    def __invert__(self):  # pragma: no cover - trivial stub
         return self
 
 
@@ -37,7 +37,7 @@ def _install_telegram_stubs() -> None:
     ext_stub = ModuleType("telegram.ext")
 
     class _DummyMessageHandler:
-        def __init__(self, *args, **kwargs):
+        def __init__(self, *args, **kwargs):  # pragma: no cover - trivial stub
             self.args = args
             self.kwargs = kwargs
 
@@ -50,6 +50,8 @@ def _install_telegram_stubs() -> None:
 
     ext_stub.Application = type("Application", (), {})
     ext_stub.ApplicationBuilder = type("ApplicationBuilder", (), {})
+    ext_stub.CommandHandler = type("CommandHandler", (), {})
+    ext_stub.CallbackQueryHandler = type("CallbackQueryHandler", (), {})
     ext_stub.MessageHandler = _DummyMessageHandler
     ext_stub.filters = filters_stub
     ext_stub.ContextTypes = _DummyContextTypes
@@ -68,23 +70,40 @@ class DummyCore:
     """Minimal core stub required for Module initialisation."""
 
 
+class FakeUpdater:
+    def __init__(self):
+        self.started = False
+        self.stopped = False
+
+    def start_polling(self):  # pragma: no cover - trivial stub
+        self.started = True
+
+    def stop(self):  # pragma: no cover - trivial stub
+        self.stopped = True
+
+
 class FakeApplication:
     def __init__(self):
-        self.handlers = []
-
-    def add_handler(self, handler):  # pragma: no cover - trivial passthrough
-        self.handlers.append(handler)
+        self.initialized = False
+        self.started = False
+        self.stopped = False
+        self.shutdown_called = False
+        self.updater = FakeUpdater()
 
     async def initialize(self):
+        self.initialized = True
         await asyncio.sleep(0)
 
     async def start(self):
+        self.started = True
         await asyncio.sleep(0)
 
     async def stop(self):
+        self.stopped = True
         await asyncio.sleep(0)
 
     async def shutdown(self):
+        self.shutdown_called = True
         await asyncio.sleep(0)
 
 
@@ -92,25 +111,21 @@ def test_runner_builds_application(monkeypatch):
     fake_app = FakeApplication()
     captured = {}
 
-    class FakeBuilder:
-        def __init__(self):
-            captured["init"] = True
+    def fake_build_application(cfg):
+        captured["token"] = cfg.telegram_token
+        captured["api_base_url"] = cfg.api_base_url
+        return fake_app
 
-        def token(self, token):
-            captured["token"] = token
-            return self
-
-        def build(self):
-            captured["built"] = True
-            return fake_app
-
-    monkeypatch.setattr(telegram_module, "ApplicationBuilder", FakeBuilder)
+    monkeypatch.setattr(telegram_module, "build_application", fake_build_application)
     monkeypatch.setattr(telegram_module.settings, "telegram_bot_token", "TEST_TOKEN")
+    monkeypatch.setattr(telegram_module.settings, "api_base", "http://example")
 
     mod = telegram_module.Module(DummyCore())
     mod._stop.set()
 
     mod._runner()
 
-    assert captured == {"init": True, "token": "TEST_TOKEN", "built": True}
+    assert captured == {"token": "TEST_TOKEN", "api_base_url": "http://example"}
     assert mod.app is fake_app
+    assert fake_app.updater.started is True
+    assert fake_app.stopped is True


### PR DESCRIPTION
## Summary
- reuse the packaged Telegram bot application when launching the module through the core service
- extend the lightweight telegram.ext stub with command and callback handler stand-ins
- update module runner tests to exercise the new application wiring

## Testing
- pytest tests/test_module_runner.py tests/test_telegram_module_runner.py

------
https://chatgpt.com/codex/tasks/task_e_68e3992aaad48323adfb82a5495e8718