### PR TITLE
Add context manager support to FastAPI stub TestClient

### DIFF
--- a/fastapi/testclient.py
+++ b/fastapi/testclient.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from types import TracebackType
+from typing import Any, Dict, Optional, Self, Type
 
 from .app import FastAPI
 from .routing import Response
@@ -17,3 +18,28 @@ class TestClient:
 
     def get(self, path: str, *, params: Optional[Dict[str, Any]] = None) -> Response:
         return self.app._handle_request("GET", path, params=params, json_body=None)
+
+    # ------------------------------------------------------------------
+    # Context manager plumbing to mirror the Starlette TestClient API.
+    # The real TestClient integrates with a transport layer that needs to
+    # be closed; our lightweight shim does not have external resources but
+    # we keep the same public surface so ``with TestClient(app)`` works even
+    # when the stub is used.  Returning ``self`` keeps usage identical to
+    # ``starlette.testclient.TestClient``.
+    # ------------------------------------------------------------------
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> bool:
+        self.close()
+        return False
+
+    def close(self) -> None:
+        """Mirror the real TestClient interface."""
+        return None
+

--- a/tests/test_fastapi_stub.py
+++ b/tests/test_fastapi_stub.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+_STUB_PACKAGE_NAME = "_fastapi_stub_pkg"
+
+
+def _load_stub_module(name: str, relative_path: str) -> ModuleType:
+    root = Path(__file__).resolve().parents[1] / "fastapi"
+    path = root / relative_path
+    package = sys.modules.get(_STUB_PACKAGE_NAME)
+    if package is None:
+        package = ModuleType(_STUB_PACKAGE_NAME)
+        package.__path__ = [str(root)]  # type: ignore[attr-defined]
+        sys.modules[_STUB_PACKAGE_NAME] = package
+
+    full_name = f"{_STUB_PACKAGE_NAME}.{name}"
+    spec = importlib.util.spec_from_file_location(full_name, path)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError(f"Unable to load stub module from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[full_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_stub_testclient_supports_context_manager() -> None:
+    _load_stub_module("exceptions", "exceptions.py")
+    _load_stub_module("params", "params.py")
+    _load_stub_module("routing", "routing.py")
+    app_module = _load_stub_module("app", "app.py")
+    testclient_module = _load_stub_module("testclient", "testclient.py")
+
+    app = app_module.FastAPI()
+    app.add_api_route("/ping", lambda: {"pong": True}, methods=["GET"])
+
+    with testclient_module.TestClient(app) as client:
+        response = client.get("/ping")
+
+    assert response.status_code == 200
+    assert response.json() == {"pong": True}


### PR DESCRIPTION
## Summary
- add context manager support to the bundled FastAPI TestClient stub so `with` usage matches the real client
- add a regression test that loads the stub modules directly and exercises the context manager

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e644e2eb688323b5ec769df9d3358a