### PR TITLE
feat: add standalone apps for analysis and text modules

### DIFF
--- a/docs/apis/analysis_module.md
+++ b/docs/apis/analysis_module.md
@@ -1,0 +1,46 @@
+# Analysis Module API
+
+## Versioned endpoint
+- **Method:** `POST`
+- **Path:** `/v1/analysis/frequency`
+- **Request body:**
+  ```json
+  {
+    "text": "To be or not to be"
+  }
+  ```
+- **Response body:**
+  ```json
+  {
+    "counts": {
+      "to": 2,
+      "be": 2,
+      "or": 1,
+      "not": 1
+    }
+  }
+  ```
+
+### Validation errors
+All validation errors use FastAPI's default error payload:
+```json
+{
+  "detail": [
+    {
+      "type": "value_error",
+      "loc": ["body", "text"],
+      "msg": "text must contain at least one non-whitespace character",
+      "input": "   "
+    }
+  ]
+}
+```
+
+## Deprecated endpoint
+- **Method:** `POST`
+- **Path:** `/analysis/frequency`
+- **Status:** Deprecated, sunset on 2025-03-31.
+- **Request body:** Same as the versioned endpoint.
+- **Response body:** Same as the versioned endpoint.
+
+Use the `/v1/analysis/frequency` endpoint for all new integrations.

--- a/docs/apis/text_module.md
+++ b/docs/apis/text_module.md
@@ -1,0 +1,42 @@
+# Text Module API
+
+## Versioned endpoint
+- **Method:** `POST`
+- **Path:** `/v1/text/uppercase`
+- **Request body:**
+  ```json
+  {
+    "text": "Hello"
+  }
+  ```
+- **Response body:**
+  ```json
+  {
+    "original": "Hello",
+    "uppercased": "HELLO"
+  }
+  ```
+
+### Validation errors
+```json
+{
+  "detail": [
+    {
+      "type": "value_error",
+      "loc": ["body", "text"],
+      "msg": "text must contain at least one visible character",
+      "input": ""
+    }
+  ]
+}
+```
+
+## Deprecated endpoint
+- **Method:** `GET`
+- **Path:** `/text/uppercase`
+- **Status:** Deprecated, sunset on 2025-03-31.
+- **Query parameters:**
+  - `text` – the string to transform.
+- **Response body:** Same as the versioned endpoint.
+
+Prefer the `/v1/text/uppercase` route for all new integrations.

--- a/modules/analysis_module/app/main.py
+++ b/modules/analysis_module/app/main.py
@@ -1,0 +1,79 @@
+"""Standalone FastAPI application for the analysis module."""
+
+from __future__ import annotations
+
+from collections import Counter
+from datetime import date
+
+from fastapi import APIRouter, FastAPI
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class FrequencyRequest(BaseModel):
+    """Request payload for the /frequency endpoint."""
+
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+    text: str = Field(..., description="Arbitrary text that will be tokenised by whitespace.")
+
+    @field_validator("text")
+    @classmethod
+    def _ensure_not_blank(cls, value: str) -> str:
+        if not value.strip():
+            msg = "text must contain at least one non-whitespace character"
+            raise ValueError(msg)
+        return value
+
+
+class FrequencyResponse(BaseModel):
+    """Response schema describing token counts."""
+
+    counts: dict[str, int]
+
+
+router = APIRouter(prefix="/v1/analysis", tags=["analysis"])
+
+
+@router.post("/frequency", response_model=FrequencyResponse, summary="Count token frequency")
+async def frequency(payload: FrequencyRequest) -> FrequencyResponse:
+    """Return a case-insensitive word frequency map for the provided text."""
+
+    tokens = [token.lower() for token in payload.text.split() if token.strip()]
+    return FrequencyResponse(counts=dict(Counter(tokens)))
+
+
+LEGACY_SUNSET = date(2025, 3, 31)
+legacy_router = APIRouter(prefix="/analysis", tags=["analysis"], deprecated=True)
+
+
+@legacy_router.post(
+    "/frequency",
+    response_model=FrequencyResponse,
+    summary="[Deprecated] Count token frequency",
+    deprecated=True,
+    openapi_extra={"sunset": LEGACY_SUNSET.isoformat()},
+)
+async def legacy_frequency(payload: FrequencyRequest) -> FrequencyResponse:
+    """Compatibility shim for the previous un-versioned endpoint."""
+
+    response = await frequency(payload)
+    return response
+
+
+app = FastAPI(
+    title="Analysis Module API",
+    version="1.0.0",
+    summary="Provides text token frequency statistics.",
+    docs_url="/docs",
+    redoc_url="/redoc",
+)
+app.include_router(router)
+app.include_router(legacy_router)
+
+
+@app.get("/openapi.json", include_in_schema=False)
+async def openapi_document() -> JSONResponse:
+    """Expose the OpenAPI document explicitly for tooling downloads."""
+
+    return JSONResponse(app.openapi())

--- a/modules/text_module/app/main.py
+++ b/modules/text_module/app/main.py
@@ -1,0 +1,79 @@
+"""Standalone FastAPI application for the text utility module."""
+
+from __future__ import annotations
+
+from datetime import date
+
+from fastapi import APIRouter, FastAPI
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class UppercaseRequest(BaseModel):
+    """Request payload for the uppercase transformation."""
+
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+    text: str = Field(..., description="Arbitrary text that will be converted to uppercase.")
+
+    @field_validator("text")
+    @classmethod
+    def _ensure_not_blank(cls, value: str) -> str:
+        if not value.strip():
+            msg = "text must contain at least one visible character"
+            raise ValueError(msg)
+        return value
+
+
+class UppercaseResponse(BaseModel):
+    """Response schema for the uppercase transformation."""
+
+    original: str
+    uppercased: str
+
+
+router = APIRouter(prefix="/v1/text", tags=["text"])
+
+
+@router.post("/uppercase", response_model=UppercaseResponse, summary="Uppercase a string")
+async def uppercase(payload: UppercaseRequest) -> UppercaseResponse:
+    """Return the uppercased form of the provided string."""
+
+    result = payload.text.upper()
+    return UppercaseResponse(original=payload.text, uppercased=result)
+
+
+LEGACY_SUNSET = date(2025, 3, 31)
+legacy_router = APIRouter(prefix="/text", tags=["text"], deprecated=True)
+
+
+@legacy_router.get(
+    "/uppercase",
+    response_model=UppercaseResponse,
+    summary="[Deprecated] Uppercase a string",
+    deprecated=True,
+    openapi_extra={"sunset": LEGACY_SUNSET.isoformat()},
+)
+async def legacy_uppercase(text: str) -> UppercaseResponse:
+    """Compatibility shim for the previous query parameter based endpoint."""
+
+    request = UppercaseRequest(text=text)
+    return await uppercase(request)
+
+
+app = FastAPI(
+    title="Text Module API",
+    version="1.0.0",
+    summary="Utility endpoints for text processing.",
+    docs_url="/docs",
+    redoc_url="/redoc",
+)
+app.include_router(router)
+app.include_router(legacy_router)
+
+
+@app.get("/openapi.json", include_in_schema=False)
+async def openapi_document() -> JSONResponse:
+    """Expose the OpenAPI schema for tooling downloads."""
+
+    return JSONResponse(app.openapi())


### PR DESCRIPTION
## Summary
- add versioned FastAPI entrypoints for the analysis and text modules with legacy route shims
- document the new endpoints under docs/apis

## Testing
- pytest *(fails: repo requires coverage extras that are not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e64f9ccec08323ab7454e6095f8686