### PR TITLE
Add OpenAPI contract and integration tests with coverage tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __pycache__/
 *.pyc
+.coverage
+coverage.xml

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: format lint typecheck test run sync
+.PHONY: format lint typecheck test run sync coverage
 
 sync:
 	uv sync
@@ -13,7 +13,12 @@ typecheck:
 	uv run mypy .
 
 test:
-	uv run pytest
+        uv run pytest
+
+coverage: test
+	mkdir -p docs/assets
+	uv run coverage-badge -o docs/assets/coverage.svg -f
+	@echo "Coverage badge written to docs/assets/coverage.svg"
 
 run:
-	uv run python -m coman.modules.main api
+        uv run python -m coman.modules.main api

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Coman Unified Platform
+# Coman Unified Platform ![Test coverage](docs/assets/coverage.svg)
 
 Coman is a modular assistant platform that bundles a FastAPI-powered core with a
 collection of pluggable automation modules (Telegram bot, orchestration logic,
@@ -53,6 +53,7 @@ make format     # Ruff formatting
 make lint       # Ruff lint checks
 make typecheck  # mypy static analysis
 make test       # pytest with coverage (fails below 85% for ``core``)
+make coverage   # pytest + badge generation at docs/assets/coverage.svg
 make run        # Launch the FastAPI application
 ```
 
@@ -62,7 +63,8 @@ fresh clone.
 ## Running the test-suite
 
 ```bash
-make test
+make test       # quick feedback
+make coverage   # refresh coverage badge
 ```
 
 ## Troubleshooting

--- a/docs/assets/coverage.svg
+++ b/docs/assets/coverage.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="99" height="20">
+    <linearGradient id="b" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+        <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+    <mask id="a">
+        <rect width="99" height="20" rx="3" fill="#fff"/>
+    </mask>
+    <g mask="url(#a)">
+        <path fill="#555" d="M0 0h63v20H0z"/>
+        <path fill="#a4a61d" d="M63 0h36v20H63z"/>
+        <path fill="url(#b)" d="M0 0h99v20H0z"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
+        <text x="31.5" y="14">coverage</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">89%</text>
+        <text x="80" y="14">89%</text>
+    </g>
+</svg>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ dev-dependencies = [
     "mypy>=1.10.0",
     "pytest>=8.3.0",
     "pytest-cov>=5.0.0",
+    "jsonschema>=4.22.0",
+    "coverage-badge>=1.1.0",
     "ruff>=0.5.0",
     "types-requests>=2.31.0.6",
 ]
@@ -65,7 +67,7 @@ check_untyped_defs = true
 
 [tool.pytest.ini_options]
 minversion = "8.0"
-addopts = "-ra --showlocals --strict-markers --strict-config --cov=core --cov-report=term-missing --cov-fail-under=85"
+addopts = "-ra --showlocals --strict-markers --strict-config --cov=core --cov-report=term-missing --cov-report=xml --cov-fail-under=85"
 testpaths = [
     "tests",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import importlib.util
 import sys
 from pathlib import Path
 
@@ -5,3 +6,16 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+# Force-load the repository's telegram shim so ``telegram.coman`` stays available.
+for key in list(sys.modules):
+    if key == "telegram" or key.startswith("telegram."):
+        sys.modules.pop(key, None)
+
+spec = importlib.util.spec_from_file_location("telegram", ROOT / "telegram" / "__init__.py")
+if spec and spec.loader:
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["telegram"] = module
+    spec.loader.exec_module(module)
+else:  # pragma: no cover - defensive fallback
+    raise RuntimeError("Unable to load local telegram shim")

--- a/tests/test_analysis_openapi_contract.py
+++ b/tests/test_analysis_openapi_contract.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import jsonschema
+import pytest
+from fastapi.testclient import TestClient
+
+from modules.analysis_module.app.main import app as analysis_app
+
+
+def _resolve_ref(schema: Mapping[str, object], document: Mapping[str, object]) -> Mapping[str, object]:
+    if "$ref" not in schema:
+        return schema
+    ref: str = schema["$ref"]  # type: ignore[assignment]
+    assert ref.startswith("#/"), "Only local references are supported in the test suite"
+    parts = ref.lstrip("#/").split("/")
+    node: object = document
+    for part in parts:
+        if isinstance(node, Mapping):
+            node = node[part]
+        else:  # pragma: no cover - defensive
+            raise KeyError(ref)
+    assert isinstance(node, Mapping)
+    return node  # type: ignore[return-value]
+
+
+def _validator(
+    schema: Mapping[str, object],
+    document: Mapping[str, object] | None = None,
+) -> jsonschema.Draft202012Validator:
+    resolver = None
+    if document is not None:
+        resolver = jsonschema.RefResolver.from_schema(document)  # type: ignore[attr-defined]
+    return jsonschema.Draft202012Validator(schema, resolver=resolver)  # type: ignore[arg-type]
+
+
+def test_analysis_openapi_contract_validates_request_and_response() -> None:
+    client = TestClient(analysis_app)
+    document = client.get("/openapi.json").json()
+    path_item = document["paths"]["/v1/analysis/frequency"]["post"]
+
+    request_schema = _resolve_ref(
+        path_item["requestBody"]["content"]["application/json"]["schema"],
+        document,
+    )
+    response_schema = _resolve_ref(
+        path_item["responses"]["200"]["content"]["application/json"]["schema"],
+        document,
+    )
+    error_schema = _resolve_ref(
+        path_item["responses"]["422"]["content"]["application/json"]["schema"],
+        document,
+    )
+
+    request_validator = _validator(request_schema, document)
+    response_validator = _validator(response_schema, document)
+    error_validator = _validator(error_schema, document)
+
+    request_validator.validate({"text": "Hello world"})
+    response = client.post("/v1/analysis/frequency", json={"text": "Hello world"})
+    assert response.status_code == 200
+    response_validator.validate(response.json())
+
+    error_response = client.post("/v1/analysis/frequency", json={"text": "   "})
+    assert error_response.status_code == 422
+    error_validator.validate(error_response.json())
+
+

--- a/tests/test_base_module_utilities.py
+++ b/tests/test_base_module_utilities.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from fastapi import Query
+
+from core.base_module import (
+    BaseModule,
+    ConsoleOperation,
+    _coerce_parameter_value,
+    _is_fastapi_param,
+    _normalise_route_methods,
+    _normalise_route_path,
+)
+
+
+class DummyRoute:
+    def __init__(self, methods: set[str] | None = None, path: str = "/demo", summary: str = "demo") -> None:
+        self.methods = methods
+        self.path = path
+        self.summary = summary
+        self.endpoint = lambda value=1: value
+        self.method = None
+        self.path_format = None
+
+
+def test_normalise_route_methods_and_path() -> None:
+    route = DummyRoute(methods={"get", "POST"}, path="/items/{item_id}")
+    assert _normalise_route_methods(route) == ["GET", "POST"]
+    assert _normalise_route_path(route) == "/items/{item_id}"
+
+
+def test_normalise_route_methods_with_single_method_attribute() -> None:
+    route = DummyRoute(methods=None)
+    route.method = "patch"
+    assert _normalise_route_methods(route) == ["PATCH"]
+
+
+def test_normalise_route_path_uses_path_format_fallback() -> None:
+    route = DummyRoute(path="")
+    route.path_format = "/formatted"
+    assert _normalise_route_path(route) == "/formatted"
+
+
+@pytest.mark.parametrize(
+    ("raw", "annotation", "expected"),
+    [
+        ("[1, 2]", list[int], [1, 2]),
+        ("{\"k\": 1}", dict[str, int], {"k": 1}),
+        ("not-json", list[str], ["not-json"]),
+    ],
+)
+def test_coerce_parameter_value_handles_json(raw: str, annotation: Any, expected: Any) -> None:
+    assert _coerce_parameter_value(raw, annotation) == expected
+
+
+def test_is_fastapi_param_detects_wrappers() -> None:
+    assert _is_fastapi_param(Query(default="value"))
+    assert not _is_fastapi_param(object())
+
+
+def test_console_operation_invokes_endpoint() -> None:
+    class DummyCore:
+        pass
+
+    module = BaseModule(DummyCore())
+
+    @module.router.get("/sample", summary="Sample")
+    def endpoint(value: int = 1) -> int:
+        return value
+
+    operations = module.get_console_operations()
+    op = operations["sample"]
+    assert isinstance(op, ConsoleOperation)
+    assert op.describe()["path"] == "/base/sample"
+    assert op.invoke({"value": 3}) == 3
+    assert module.describe_console_operations()[0]["methods"] == ["GET"]
+
+    with pytest.raises(KeyError):
+        module.invoke_console_operation("unknown")

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from core import config
+
+
+def test_split_paths_normalises_and_deduplicates(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    raw = " ./one , /tmp/two , ./one , ./THREE "
+    expected = {
+        str((tmp_path / "one").resolve()),
+        "/tmp/two",
+        str((tmp_path / "THREE").resolve()),
+    }
+    result = config._split_paths(raw)
+    assert len(result) == len(set(result))
+    assert expected.issubset(set(result))
+
+
+def test_split_paths_defaults_to_project_locations(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+    result = config._split_paths("")
+    cwd = str(tmp_path.resolve())
+    assert result[0] == cwd
+    expected_second = str((tmp_path / "integrations").resolve())
+    assert expected_second in result
+    assert len(result) == 2
+
+
+def test_settings_stores_and_clears_token(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("COMAN_DATA_DIR", str(tmp_path))
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    settings = config.Settings()
+
+    settings.store_telegram_bot_token("  secret  ")
+    token_file = tmp_path / "telegram_token.txt"
+    assert token_file.read_text(encoding="utf-8") == "secret"
+    assert settings.telegram_bot_token == "secret"
+    assert settings.telegram_token_source == "file"
+
+    settings.store_telegram_bot_token("")
+    assert not token_file.exists()
+    assert settings.telegram_bot_token == ""
+    assert settings.telegram_token_source == "none"
+
+
+def test_settings_prefers_environment_token(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("COMAN_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "from-env")
+    settings = config.Settings()
+
+    settings.store_telegram_bot_token("")
+    assert settings.telegram_bot_token == "from-env"
+    assert settings.telegram_token_source == "env"

--- a/tests/test_core_logger.py
+++ b/tests/test_core_logger.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import logging
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+
+class _DummyRichHandler:
+    def __init__(self, rich_tracebacks: bool = False) -> None:
+        self.rich_tracebacks = rich_tracebacks
+
+
+_rich_logging = SimpleNamespace(RichHandler=_DummyRichHandler)
+sys.modules.setdefault("rich", SimpleNamespace(logging=_rich_logging))
+sys.modules.setdefault("rich.logging", _rich_logging)
+
+from core import logger as core_logger
+
+
+def test_get_logger_respects_environment_level(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_basic_config(**kwargs: object) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setenv("COMAN_LOG_LEVEL", "debug")
+    monkeypatch.setattr(core_logger.logging, "basicConfig", fake_basic_config)
+
+    log = core_logger.get_logger("integration-test")
+
+    assert captured["level"] == "DEBUG"
+    handlers = captured.get("handlers")
+    assert handlers and any(isinstance(h, core_logger.RichHandler) for h in handlers)
+    assert log.name == "integration-test"

--- a/tests/test_core_registry.py
+++ b/tests/test_core_registry.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from core import registry
+from core.base_module import BaseModule
+
+
+class DummyModule(BaseModule):
+    name = "dummy"
+
+    def __init__(self, core: registry.Core):
+        super().__init__(core)
+
+
+def test_load_modules_registers_discovered_packages(monkeypatch: pytest.MonkeyPatch) -> None:
+    core = registry.Core()
+
+    dummy_package = types.SimpleNamespace(__path__=[], __name__="coman.modules")
+
+    def fake_import(name: str):
+        if name == "coman.modules":
+            return dummy_package
+        return types.SimpleNamespace(Module=DummyModule)
+
+    monkeypatch.setattr(registry.importlib, "import_module", fake_import)
+
+    def fake_iter_modules(path, prefix):
+        assert prefix == "coman.modules."
+        return [types.SimpleNamespace(name="coman.modules.dummy", ispkg=True)]
+
+    monkeypatch.setattr(registry.pkgutil, "iter_modules", lambda *args, **kwargs: fake_iter_modules(*args, **kwargs))
+
+    registry.load_modules(core)
+    assert "dummy" in core.modules
+    assert isinstance(core.modules["dummy"], DummyModule)
+
+
+def test_load_modules_skips_packages_without_module(monkeypatch: pytest.MonkeyPatch) -> None:
+    core = registry.Core()
+
+    monkeypatch.setattr(registry.importlib, "import_module", lambda name: types.SimpleNamespace() if name != "coman.modules" else types.SimpleNamespace(__path__=[], __name__="coman.modules"))
+
+    monkeypatch.setattr(
+        registry.pkgutil,
+        "iter_modules",
+        lambda *args, **kwargs: [types.SimpleNamespace(name="coman.modules.empty", ispkg=True)],
+    )
+
+    registry.load_modules(core)
+    assert core.modules == {}

--- a/tests/test_core_scheduler.py
+++ b/tests/test_core_scheduler.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import pytest
+
+from core import scheduler
+
+
+def test_scheduler_wraps_asyncio_scheduler(monkeypatch: pytest.MonkeyPatch) -> None:
+    events: list[str] = []
+
+    class FakeScheduler:
+        def start(self) -> None:
+            events.append("start")
+
+        def shutdown(self, wait: bool = False) -> None:
+            events.append(f"shutdown:{wait}")
+
+        def add_job(self, func, trigger, name: str):
+            events.append(f"job:{name}:{trigger}")
+
+    class FakeTrigger:
+        @staticmethod
+        def from_crontab(expr: str) -> str:
+            return f"cron:{expr}"
+
+    monkeypatch.setattr(scheduler, "AsyncIOScheduler", FakeScheduler)
+    monkeypatch.setattr(scheduler, "CronTrigger", FakeTrigger)
+
+    sched = scheduler.Scheduler()
+    sched.start()
+    sched.add_cron(lambda: None, "*/5 * * * *", name="heartbeat")
+    sched.shutdown()
+
+    assert events == ["start", "job:heartbeat:cron:*/5 * * * *", "shutdown:False"]
+
+
+def test_scheduler_noop_when_dependency_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(scheduler, "AsyncIOScheduler", None)
+    monkeypatch.setattr(scheduler, "CronTrigger", None)
+
+    sched = scheduler.Scheduler()
+    sched.start()
+    sched.add_cron(lambda: None, "* * * * *", name="noop")
+    sched.shutdown()

--- a/tests/test_manager_text_integration.py
+++ b/tests/test_manager_text_integration.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from core.app import build_fastapi_app
+from core.registry import Core
+from modules.manager import module as manager_module
+from modules.text_module import module as text_module
+
+
+class _LocalHttpClient:
+    def __init__(self, test_client: TestClient, base_url: str) -> None:
+        self._client = test_client
+        self._base_url = base_url.rstrip("/")
+
+    def __enter__(self) -> "_LocalHttpClient":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:  # type: ignore[override]
+        return False
+
+    def _request(self, method: str, url: str, **kwargs: Any):
+        assert url.startswith(self._base_url)
+        path = url[len(self._base_url) :]
+        if not path:
+            path = "/"
+        return self._client.request(method, path, **kwargs)
+
+    def get(self, url: str, **kwargs: Any):
+        return self._request("GET", url, **kwargs)
+
+    def post(self, url: str, **kwargs: Any):
+        return self._request("POST", url, **kwargs)
+
+
+def test_manager_invokes_text_module_end_to_end(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(manager_module, "mount_ui", lambda _app: None, raising=False)
+    monkeypatch.setattr("core.app.mount_ui", lambda _app: None)
+
+    monkeypatch.setattr(manager_module.settings, "data_dir", str(tmp_path), raising=False)
+    monkeypatch.setattr(manager_module.settings, "api_base", "http://testserver", raising=False)
+
+    core = Core()
+    manager = manager_module.Module(core)
+    text = text_module.Module(core)
+    core.modules = {manager.name: manager, text.name: text}
+
+    app = build_fastapi_app(core)
+    client = TestClient(app)
+    base_url = str(client.base_url).rstrip("/")
+    monkeypatch.setattr(manager_module.settings, "api_base", base_url, raising=False)
+
+    def _client_factory(*args: Any, **kwargs: Any) -> _LocalHttpClient:
+        return _LocalHttpClient(client, base_url)
+
+    monkeypatch.setattr(manager_module.httpx, "Client", _client_factory)
+
+    registry = manager_module.ToolRegistry()
+    registry.upsert(
+        manager_module.ToolDefinition(
+            name="text.uppercase",
+            method="GET",
+            path="/text/uppercase",
+            params=["s"],
+        )
+    )
+    manager_module.save_tools(registry)
+
+    response = client.post("/manager/run", json={"goal": "uppercase this", "inputs": {}})
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["tool"] == "text.uppercase"
+    assert payload["result"]["result"] == "UPPERCASE THIS"

--- a/tests/test_messages_base.py
+++ b/tests/test_messages_base.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pydantic import Field
+
+from core.messages.base import ModuleMessage
+
+
+class SampleMessage(ModuleMessage):
+    identifier: int = 0
+    alias_value: str = Field(default="", alias="aliasValue")
+
+
+def test_module_message_from_payload_handles_aliases_and_unknown_fields() -> None:
+    payload = {"identifier": "7", "aliasValue": "value", "ignored": "data"}
+    message = SampleMessage.from_payload(payload)
+    assert message.identifier == 7
+    assert message.alias_value == "value"
+    assert message.to_payload() == {"identifier": 7, "alias_value": "value"}
+
+
+def test_module_message_clone_updates_fields() -> None:
+    original = SampleMessage(identifier=1, alias_value="alpha")
+    cloned = original.clone(identifier=2)
+    assert cloned.identifier == 2
+    assert cloned.alias_value == "alpha"
+    assert original.identifier == 1

--- a/tests/test_messages_manager_models.py
+++ b/tests/test_messages_manager_models.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from core.messages.manager import (
+    ManagerRunRequest,
+    ManagerRunResult,
+    ToolDefinition,
+    ToolRegistry,
+)
+
+
+def test_tool_definition_normalises_payload() -> None:
+    payload = {
+        "name": "example",
+        "method": "post",
+        "path": "/v1/example",
+        "params": "a, b ,",
+    }
+    tool = ToolDefinition.from_payload(payload)
+    assert tool.method == "POST"
+    assert tool.params == ["a", "b"]
+
+
+def test_tool_registry_roundtrip_and_lookup() -> None:
+    tools = [
+        ToolDefinition(name="first", path="/a"),
+        ToolDefinition(name="second", path="/b"),
+    ]
+    registry = ToolRegistry.from_tools(tools)
+    registry.upsert(ToolDefinition(name="first", path="/other"))
+
+    assert registry.names() == ["second", "first"]
+    found = registry.find("first")
+    assert found is not None
+    assert found.path == "/other"
+
+
+def test_manager_run_request_sanitises_inputs() -> None:
+    payload = {
+        "goal": "  explore  ",
+        "inputs": ["not", "a", "dict"],
+        "metadata": None,
+    }
+    request = ManagerRunRequest.from_payload(payload)
+    assert request.goal == "explore"
+    assert request.inputs == {}
+    assert request.metadata == {}
+
+
+def test_manager_run_result_sets_known_tools() -> None:
+    registry = ToolRegistry()
+    result = ManagerRunResult(goal="demo").set_known_tools(registry)
+    assert result.known_tools is registry

--- a/tests/test_text_openapi_contract.py
+++ b/tests/test_text_openapi_contract.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import jsonschema
+import pytest
+from fastapi.testclient import TestClient
+
+from modules.text_module.app.main import app as text_app
+
+
+def _resolve_ref(schema: Mapping[str, object], document: Mapping[str, object]) -> Mapping[str, object]:
+    if "$ref" not in schema:
+        return schema
+    ref: str = schema["$ref"]  # type: ignore[assignment]
+    assert ref.startswith("#/"), "Only local references are supported in the test suite"
+    parts = ref.lstrip("#/").split("/")
+    node: object = document
+    for part in parts:
+        if isinstance(node, Mapping):
+            node = node[part]
+        else:  # pragma: no cover - defensive
+            raise KeyError(ref)
+    assert isinstance(node, Mapping)
+    return node  # type: ignore[return-value]
+
+
+def _validator(
+    schema: Mapping[str, object],
+    document: Mapping[str, object] | None = None,
+) -> jsonschema.Draft202012Validator:
+    resolver = None
+    if document is not None:
+        resolver = jsonschema.RefResolver.from_schema(document)  # type: ignore[attr-defined]
+    return jsonschema.Draft202012Validator(schema, resolver=resolver)  # type: ignore[arg-type]
+
+
+def test_text_openapi_contract_validates_request_response_and_legacy() -> None:
+    client = TestClient(text_app)
+    document = client.get("/openapi.json").json()
+    post_path = document["paths"]["/v1/text/uppercase"]["post"]
+
+    request_schema = _resolve_ref(
+        post_path["requestBody"]["content"]["application/json"]["schema"],
+        document,
+    )
+    response_schema = _resolve_ref(
+        post_path["responses"]["200"]["content"]["application/json"]["schema"],
+        document,
+    )
+    error_schema = _resolve_ref(
+        post_path["responses"]["422"]["content"]["application/json"]["schema"],
+        document,
+    )
+
+    request_validator = _validator(request_schema, document)
+    response_validator = _validator(response_schema, document)
+    error_validator = _validator(error_schema, document)
+
+    request_validator.validate({"text": "Hello"})
+    response = client.post("/v1/text/uppercase", json={"text": "Hello"})
+    assert response.status_code == 200
+    response_validator.validate(response.json())
+
+    legacy_response = client.get("/text/uppercase", params={"text": "Hello"})
+    assert legacy_response.status_code == 200
+    response_validator.validate(legacy_response.json())
+
+    error_response = client.post("/v1/text/uppercase", json={"text": "   "})
+    assert error_response.status_code == 422
+    error_validator.validate(error_response.json())

--- a/uv.lock
+++ b/uv.lock
@@ -38,6 +38,15 @@ wheels = [
 ]
 
 [[package]]
+name = "attrs"
+version = "25.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/5c/685e6633917e101e5dcb62b9dd76946cbb57c26e133bae9e0cd36033c0a9/attrs-25.4.0.tar.gz", hash = "sha256:16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11", size = 934251, upload-time = "2025-10-06T13:54:44.725Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl", hash = "sha256:adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373", size = 67615, upload-time = "2025-10-06T13:54:43.17Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2025.10.5"
 source = { registry = "https://pypi.org/simple" }
@@ -114,6 +123,8 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "coverage-badge" },
+    { name = "jsonschema" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -135,6 +146,8 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "coverage-badge", specifier = ">=1.1.0" },
+    { name = "jsonschema", specifier = ">=4.22.0" },
     { name = "mypy", specifier = ">=1.10.0" },
     { name = "pytest", specifier = ">=8.3.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
@@ -217,6 +230,19 @@ wheels = [
 ]
 
 [[package]]
+name = "coverage-badge"
+version = "1.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/8f/e92b0a010c76b0da82709838b3f3ae9aec638d0c44dbfb1186a5751f5d2e/coverage_badge-1.1.2.tar.gz", hash = "sha256:fe7ed58a3b72dad85a553b64a99e963dea3847dcd0b8ddd2b38a00333618642c", size = 6335, upload-time = "2024-08-02T23:34:08.58Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/3d/5642a1a06191b2e1e0f87a2e824e6d3eb7c32c589a68ed4d1dcbd3324d63/coverage_badge-1.1.2-py2.py3-none-any.whl", hash = "sha256:d8413ce51c91043a1692b943616b450868cbeeb0ea6a0c54a32f8318c9c96ff7", size = 6493, upload-time = "2024-08-02T23:34:07.063Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.115.14"
 source = { registry = "https://pypi.org/simple" }
@@ -295,6 +321,33 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.25.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/69/f7185de793a29082a9f3c7728268ffb31cb5095131a9c139a74078e27336/jsonschema-4.25.1.tar.gz", hash = "sha256:e4a9655ce0da0c0b67a085847e00a3a51449e1157f4f75e9fb5aa545e122eb85", size = 357342, upload-time = "2025-08-18T17:03:50.038Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl", hash = "sha256:3fba0169e345c7175110351d456342c364814cfcf3b964ba4587f22915230a63", size = 90040, upload-time = "2025-08-18T17:03:48.373Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
 ]
 
 [[package]]
@@ -567,6 +620,20 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.36.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2f/db/98b5c277be99dd18bfd91dd04e1b759cad18d1a338188c936e92f921c7e2/referencing-0.36.2.tar.gz", hash = "sha256:df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa", size = 74744, upload-time = "2025-01-25T08:48:16.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/b1/3baf80dc6d2b7bc27a95a67752d0208e410351e3feb4eb78de5f77454d8d/referencing-0.36.2-py3-none-any.whl", hash = "sha256:e8699adbbf8b5c7de96d8ffa0eb5c158b3beafce084968e2ea8bb08c6794dcd0", size = 26775, upload-time = "2025-01-25T08:48:14.241Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.32.5"
 source = { registry = "https://pypi.org/simple" }
@@ -579,6 +646,87 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "0.27.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/dd/2c0cbe774744272b0ae725f44032c77bdcab6e8bcf544bffa3b6e70c8dba/rpds_py-0.27.1.tar.gz", hash = "sha256:26a1c73171d10b7acccbded82bf6a586ab8203601e565badc74bbbf8bc5a10f8", size = 27479, upload-time = "2025-08-27T12:16:36.024Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/fe/38de28dee5df58b8198c743fe2bea0c785c6d40941b9950bac4cdb71a014/rpds_py-0.27.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:ae2775c1973e3c30316892737b91f9283f9908e3cc7625b9331271eaaed7dc90", size = 361887, upload-time = "2025-08-27T12:13:10.233Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/9a/4b6c7eedc7dd90986bf0fab6ea2a091ec11c01b15f8ba0a14d3f80450468/rpds_py-0.27.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2643400120f55c8a96f7c9d858f7be0c88d383cd4653ae2cf0d0c88f668073e5", size = 345795, upload-time = "2025-08-27T12:13:11.65Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/0e/e650e1b81922847a09cca820237b0edee69416a01268b7754d506ade11ad/rpds_py-0.27.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:16323f674c089b0360674a4abd28d5042947d54ba620f72514d69be4ff64845e", size = 385121, upload-time = "2025-08-27T12:13:13.008Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/ea/b306067a712988e2bff00dcc7c8f31d26c29b6d5931b461aa4b60a013e33/rpds_py-0.27.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9a1f4814b65eacac94a00fc9a526e3fdafd78e439469644032032d0d63de4881", size = 398976, upload-time = "2025-08-27T12:13:14.368Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/0a/26dc43c8840cb8fe239fe12dbc8d8de40f2365e838f3d395835dde72f0e5/rpds_py-0.27.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7ba32c16b064267b22f1850a34051121d423b6f7338a12b9459550eb2096e7ec", size = 525953, upload-time = "2025-08-27T12:13:15.774Z" },
+    { url = "https://files.pythonhosted.org/packages/22/14/c85e8127b573aaf3a0cbd7fbb8c9c99e735a4a02180c84da2a463b766e9e/rpds_py-0.27.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5c20f33fd10485b80f65e800bbe5f6785af510b9f4056c5a3c612ebc83ba6cb", size = 407915, upload-time = "2025-08-27T12:13:17.379Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/7b/8f4fee9ba1fb5ec856eb22d725a4efa3deb47f769597c809e03578b0f9d9/rpds_py-0.27.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:466bfe65bd932da36ff279ddd92de56b042f2266d752719beb97b08526268ec5", size = 386883, upload-time = "2025-08-27T12:13:18.704Z" },
+    { url = "https://files.pythonhosted.org/packages/86/47/28fa6d60f8b74fcdceba81b272f8d9836ac0340570f68f5df6b41838547b/rpds_py-0.27.1-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:41e532bbdcb57c92ba3be62c42e9f096431b4cf478da9bc3bc6ce5c38ab7ba7a", size = 405699, upload-time = "2025-08-27T12:13:20.089Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/fd/c5987b5e054548df56953a21fe2ebed51fc1ec7c8f24fd41c067b68c4a0a/rpds_py-0.27.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f149826d742b406579466283769a8ea448eed82a789af0ed17b0cd5770433444", size = 423713, upload-time = "2025-08-27T12:13:21.436Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ba/3c4978b54a73ed19a7d74531be37a8bcc542d917c770e14d372b8daea186/rpds_py-0.27.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:80c60cfb5310677bd67cb1e85a1e8eb52e12529545441b43e6f14d90b878775a", size = 562324, upload-time = "2025-08-27T12:13:22.789Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/6c/6943a91768fec16db09a42b08644b960cff540c66aab89b74be6d4a144ba/rpds_py-0.27.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:7ee6521b9baf06085f62ba9c7a3e5becffbc32480d2f1b351559c001c38ce4c1", size = 593646, upload-time = "2025-08-27T12:13:24.122Z" },
+    { url = "https://files.pythonhosted.org/packages/11/73/9d7a8f4be5f4396f011a6bb7a19fe26303a0dac9064462f5651ced2f572f/rpds_py-0.27.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a512c8263249a9d68cac08b05dd59d2b3f2061d99b322813cbcc14c3c7421998", size = 558137, upload-time = "2025-08-27T12:13:25.557Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/96/6772cbfa0e2485bcceef8071de7821f81aeac8bb45fbfd5542a3e8108165/rpds_py-0.27.1-cp312-cp312-win32.whl", hash = "sha256:819064fa048ba01b6dadc5116f3ac48610435ac9a0058bbde98e569f9e785c39", size = 221343, upload-time = "2025-08-27T12:13:26.967Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b6/c82f0faa9af1c6a64669f73a17ee0eeef25aff30bb9a1c318509efe45d84/rpds_py-0.27.1-cp312-cp312-win_amd64.whl", hash = "sha256:d9199717881f13c32c4046a15f024971a3b78ad4ea029e8da6b86e5aa9cf4594", size = 232497, upload-time = "2025-08-27T12:13:28.326Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/96/2817b44bd2ed11aebacc9251da03689d56109b9aba5e311297b6902136e2/rpds_py-0.27.1-cp312-cp312-win_arm64.whl", hash = "sha256:33aa65b97826a0e885ef6e278fbd934e98cdcfed80b63946025f01e2f5b29502", size = 222790, upload-time = "2025-08-27T12:13:29.71Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/77/610aeee8d41e39080c7e14afa5387138e3c9fa9756ab893d09d99e7d8e98/rpds_py-0.27.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:e4b9fcfbc021633863a37e92571d6f91851fa656f0180246e84cbd8b3f6b329b", size = 361741, upload-time = "2025-08-27T12:13:31.039Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/fc/c43765f201c6a1c60be2043cbdb664013def52460a4c7adace89d6682bf4/rpds_py-0.27.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1441811a96eadca93c517d08df75de45e5ffe68aa3089924f963c782c4b898cf", size = 345574, upload-time = "2025-08-27T12:13:32.902Z" },
+    { url = "https://files.pythonhosted.org/packages/20/42/ee2b2ca114294cd9847d0ef9c26d2b0851b2e7e00bf14cc4c0b581df0fc3/rpds_py-0.27.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55266dafa22e672f5a4f65019015f90336ed31c6383bd53f5e7826d21a0e0b83", size = 385051, upload-time = "2025-08-27T12:13:34.228Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e8/1e430fe311e4799e02e2d1af7c765f024e95e17d651612425b226705f910/rpds_py-0.27.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d78827d7ac08627ea2c8e02c9e5b41180ea5ea1f747e9db0915e3adf36b62dcf", size = 398395, upload-time = "2025-08-27T12:13:36.132Z" },
+    { url = "https://files.pythonhosted.org/packages/82/95/9dc227d441ff2670651c27a739acb2535ccaf8b351a88d78c088965e5996/rpds_py-0.27.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ae92443798a40a92dc5f0b01d8a7c93adde0c4dc965310a29ae7c64d72b9fad2", size = 524334, upload-time = "2025-08-27T12:13:37.562Z" },
+    { url = "https://files.pythonhosted.org/packages/87/01/a670c232f401d9ad461d9a332aa4080cd3cb1d1df18213dbd0d2a6a7ab51/rpds_py-0.27.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c46c9dd2403b66a2a3b9720ec4b74d4ab49d4fabf9f03dfdce2d42af913fe8d0", size = 407691, upload-time = "2025-08-27T12:13:38.94Z" },
+    { url = "https://files.pythonhosted.org/packages/03/36/0a14aebbaa26fe7fab4780c76f2239e76cc95a0090bdb25e31d95c492fcd/rpds_py-0.27.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2efe4eb1d01b7f5f1939f4ef30ecea6c6b3521eec451fb93191bf84b2a522418", size = 386868, upload-time = "2025-08-27T12:13:40.192Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/03/8c897fb8b5347ff6c1cc31239b9611c5bf79d78c984430887a353e1409a1/rpds_py-0.27.1-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:15d3b4d83582d10c601f481eca29c3f138d44c92187d197aff663a269197c02d", size = 405469, upload-time = "2025-08-27T12:13:41.496Z" },
+    { url = "https://files.pythonhosted.org/packages/da/07/88c60edc2df74850d496d78a1fdcdc7b54360a7f610a4d50008309d41b94/rpds_py-0.27.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4ed2e16abbc982a169d30d1a420274a709949e2cbdef119fe2ec9d870b42f274", size = 422125, upload-time = "2025-08-27T12:13:42.802Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/86/5f4c707603e41b05f191a749984f390dabcbc467cf833769b47bf14ba04f/rpds_py-0.27.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a75f305c9b013289121ec0f1181931975df78738cdf650093e6b86d74aa7d8dd", size = 562341, upload-time = "2025-08-27T12:13:44.472Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/92/3c0cb2492094e3cd9baf9e49bbb7befeceb584ea0c1a8b5939dca4da12e5/rpds_py-0.27.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:67ce7620704745881a3d4b0ada80ab4d99df390838839921f99e63c474f82cf2", size = 592511, upload-time = "2025-08-27T12:13:45.898Z" },
+    { url = "https://files.pythonhosted.org/packages/10/bb/82e64fbb0047c46a168faa28d0d45a7851cd0582f850b966811d30f67ad8/rpds_py-0.27.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9d992ac10eb86d9b6f369647b6a3f412fc0075cfd5d799530e84d335e440a002", size = 557736, upload-time = "2025-08-27T12:13:47.408Z" },
+    { url = "https://files.pythonhosted.org/packages/00/95/3c863973d409210da7fb41958172c6b7dbe7fc34e04d3cc1f10bb85e979f/rpds_py-0.27.1-cp313-cp313-win32.whl", hash = "sha256:4f75e4bd8ab8db624e02c8e2fc4063021b58becdbe6df793a8111d9343aec1e3", size = 221462, upload-time = "2025-08-27T12:13:48.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/2c/5867b14a81dc217b56d95a9f2a40fdbc56a1ab0181b80132beeecbd4b2d6/rpds_py-0.27.1-cp313-cp313-win_amd64.whl", hash = "sha256:f9025faafc62ed0b75a53e541895ca272815bec18abe2249ff6501c8f2e12b83", size = 232034, upload-time = "2025-08-27T12:13:50.11Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/78/3958f3f018c01923823f1e47f1cc338e398814b92d83cd278364446fac66/rpds_py-0.27.1-cp313-cp313-win_arm64.whl", hash = "sha256:ed10dc32829e7d222b7d3b93136d25a406ba9788f6a7ebf6809092da1f4d279d", size = 222392, upload-time = "2025-08-27T12:13:52.587Z" },
+    { url = "https://files.pythonhosted.org/packages/01/76/1cdf1f91aed5c3a7bf2eba1f1c4e4d6f57832d73003919a20118870ea659/rpds_py-0.27.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:92022bbbad0d4426e616815b16bc4127f83c9a74940e1ccf3cfe0b387aba0228", size = 358355, upload-time = "2025-08-27T12:13:54.012Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/6f/bf142541229374287604caf3bb2a4ae17f0a580798fd72d3b009b532db4e/rpds_py-0.27.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:47162fdab9407ec3f160805ac3e154df042e577dd53341745fc7fb3f625e6d92", size = 342138, upload-time = "2025-08-27T12:13:55.791Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/77/355b1c041d6be40886c44ff5e798b4e2769e497b790f0f7fd1e78d17e9a8/rpds_py-0.27.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fb89bec23fddc489e5d78b550a7b773557c9ab58b7946154a10a6f7a214a48b2", size = 380247, upload-time = "2025-08-27T12:13:57.683Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a4/d9cef5c3946ea271ce2243c51481971cd6e34f21925af2783dd17b26e815/rpds_py-0.27.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e48af21883ded2b3e9eb48cb7880ad8598b31ab752ff3be6457001d78f416723", size = 390699, upload-time = "2025-08-27T12:13:59.137Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/06/005106a7b8c6c1a7e91b73169e49870f4af5256119d34a361ae5240a0c1d/rpds_py-0.27.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6f5b7bd8e219ed50299e58551a410b64daafb5017d54bbe822e003856f06a802", size = 521852, upload-time = "2025-08-27T12:14:00.583Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/3e/50fb1dac0948e17a02eb05c24510a8fe12d5ce8561c6b7b7d1339ab7ab9c/rpds_py-0.27.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:08f1e20bccf73b08d12d804d6e1c22ca5530e71659e6673bce31a6bb71c1e73f", size = 402582, upload-time = "2025-08-27T12:14:02.034Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/b0/f4e224090dc5b0ec15f31a02d746ab24101dd430847c4d99123798661bfc/rpds_py-0.27.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0dc5dceeaefcc96dc192e3a80bbe1d6c410c469e97bdd47494a7d930987f18b2", size = 384126, upload-time = "2025-08-27T12:14:03.437Z" },
+    { url = "https://files.pythonhosted.org/packages/54/77/ac339d5f82b6afff1df8f0fe0d2145cc827992cb5f8eeb90fc9f31ef7a63/rpds_py-0.27.1-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:d76f9cc8665acdc0c9177043746775aa7babbf479b5520b78ae4002d889f5c21", size = 399486, upload-time = "2025-08-27T12:14:05.443Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/29/3e1c255eee6ac358c056a57d6d6869baa00a62fa32eea5ee0632039c50a3/rpds_py-0.27.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:134fae0e36022edad8290a6661edf40c023562964efea0cc0ec7f5d392d2aaef", size = 414832, upload-time = "2025-08-27T12:14:06.902Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/db/6d498b844342deb3fa1d030598db93937a9964fcf5cb4da4feb5f17be34b/rpds_py-0.27.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:eb11a4f1b2b63337cfd3b4d110af778a59aae51c81d195768e353d8b52f88081", size = 557249, upload-time = "2025-08-27T12:14:08.37Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f3/690dd38e2310b6f68858a331399b4d6dbb9132c3e8ef8b4333b96caf403d/rpds_py-0.27.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:13e608ac9f50a0ed4faec0e90ece76ae33b34c0e8656e3dceb9a7db994c692cd", size = 587356, upload-time = "2025-08-27T12:14:10.034Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e3/84507781cccd0145f35b1dc32c72675200c5ce8d5b30f813e49424ef68fc/rpds_py-0.27.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dd2135527aa40f061350c3f8f89da2644de26cd73e4de458e79606384f4f68e7", size = 555300, upload-time = "2025-08-27T12:14:11.783Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/ee/375469849e6b429b3516206b4580a79e9ef3eb12920ddbd4492b56eaacbe/rpds_py-0.27.1-cp313-cp313t-win32.whl", hash = "sha256:3020724ade63fe320a972e2ffd93b5623227e684315adce194941167fee02688", size = 216714, upload-time = "2025-08-27T12:14:13.629Z" },
+    { url = "https://files.pythonhosted.org/packages/21/87/3fc94e47c9bd0742660e84706c311a860dcae4374cf4a03c477e23ce605a/rpds_py-0.27.1-cp313-cp313t-win_amd64.whl", hash = "sha256:8ee50c3e41739886606388ba3ab3ee2aae9f35fb23f833091833255a31740797", size = 228943, upload-time = "2025-08-27T12:14:14.937Z" },
+    { url = "https://files.pythonhosted.org/packages/70/36/b6e6066520a07cf029d385de869729a895917b411e777ab1cde878100a1d/rpds_py-0.27.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:acb9aafccaae278f449d9c713b64a9e68662e7799dbd5859e2c6b3c67b56d334", size = 362472, upload-time = "2025-08-27T12:14:16.333Z" },
+    { url = "https://files.pythonhosted.org/packages/af/07/b4646032e0dcec0df9c73a3bd52f63bc6c5f9cda992f06bd0e73fe3fbebd/rpds_py-0.27.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b7fb801aa7f845ddf601c49630deeeccde7ce10065561d92729bfe81bd21fb33", size = 345676, upload-time = "2025-08-27T12:14:17.764Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/16/2f1003ee5d0af4bcb13c0cf894957984c32a6751ed7206db2aee7379a55e/rpds_py-0.27.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fe0dd05afb46597b9a2e11c351e5e4283c741237e7f617ffb3252780cca9336a", size = 385313, upload-time = "2025-08-27T12:14:19.829Z" },
+    { url = "https://files.pythonhosted.org/packages/05/cd/7eb6dd7b232e7f2654d03fa07f1414d7dfc980e82ba71e40a7c46fd95484/rpds_py-0.27.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b6dfb0e058adb12d8b1d1b25f686e94ffa65d9995a5157afe99743bf7369d62b", size = 399080, upload-time = "2025-08-27T12:14:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/20/51/5829afd5000ec1cb60f304711f02572d619040aa3ec033d8226817d1e571/rpds_py-0.27.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ed090ccd235f6fa8bb5861684567f0a83e04f52dfc2e5c05f2e4b1309fcf85e7", size = 523868, upload-time = "2025-08-27T12:14:23.485Z" },
+    { url = "https://files.pythonhosted.org/packages/05/2c/30eebca20d5db95720ab4d2faec1b5e4c1025c473f703738c371241476a2/rpds_py-0.27.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bf876e79763eecf3e7356f157540d6a093cef395b65514f17a356f62af6cc136", size = 408750, upload-time = "2025-08-27T12:14:24.924Z" },
+    { url = "https://files.pythonhosted.org/packages/90/1a/cdb5083f043597c4d4276eae4e4c70c55ab5accec078da8611f24575a367/rpds_py-0.27.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:12ed005216a51b1d6e2b02a7bd31885fe317e45897de81d86dcce7d74618ffff", size = 387688, upload-time = "2025-08-27T12:14:27.537Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/92/cf786a15320e173f945d205ab31585cc43969743bb1a48b6888f7a2b0a2d/rpds_py-0.27.1-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:ee4308f409a40e50593c7e3bb8cbe0b4d4c66d1674a316324f0c2f5383b486f9", size = 407225, upload-time = "2025-08-27T12:14:28.981Z" },
+    { url = "https://files.pythonhosted.org/packages/33/5c/85ee16df5b65063ef26017bef33096557a4c83fbe56218ac7cd8c235f16d/rpds_py-0.27.1-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0b08d152555acf1f455154d498ca855618c1378ec810646fcd7c76416ac6dc60", size = 423361, upload-time = "2025-08-27T12:14:30.469Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8e/1c2741307fcabd1a334ecf008e92c4f47bb6f848712cf15c923becfe82bb/rpds_py-0.27.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:dce51c828941973a5684d458214d3a36fcd28da3e1875d659388f4f9f12cc33e", size = 562493, upload-time = "2025-08-27T12:14:31.987Z" },
+    { url = "https://files.pythonhosted.org/packages/04/03/5159321baae9b2222442a70c1f988cbbd66b9be0675dd3936461269be360/rpds_py-0.27.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:c1476d6f29eb81aa4151c9a31219b03f1f798dc43d8af1250a870735516a1212", size = 592623, upload-time = "2025-08-27T12:14:33.543Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/39/c09fd1ad28b85bc1d4554a8710233c9f4cefd03d7717a1b8fbfd171d1167/rpds_py-0.27.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:3ce0cac322b0d69b63c9cdb895ee1b65805ec9ffad37639f291dd79467bee675", size = 558800, upload-time = "2025-08-27T12:14:35.436Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/d6/99228e6bbcf4baa764b18258f519a9035131d91b538d4e0e294313462a98/rpds_py-0.27.1-cp314-cp314-win32.whl", hash = "sha256:dfbfac137d2a3d0725758cd141f878bf4329ba25e34979797c89474a89a8a3a3", size = 221943, upload-time = "2025-08-27T12:14:36.898Z" },
+    { url = "https://files.pythonhosted.org/packages/be/07/c802bc6b8e95be83b79bdf23d1aa61d68324cb1006e245d6c58e959e314d/rpds_py-0.27.1-cp314-cp314-win_amd64.whl", hash = "sha256:a6e57b0abfe7cc513450fcf529eb486b6e4d3f8aee83e92eb5f1ef848218d456", size = 233739, upload-time = "2025-08-27T12:14:38.386Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/89/3e1b1c16d4c2d547c5717377a8df99aee8099ff050f87c45cb4d5fa70891/rpds_py-0.27.1-cp314-cp314-win_arm64.whl", hash = "sha256:faf8d146f3d476abfee026c4ae3bdd9ca14236ae4e4c310cbd1cf75ba33d24a3", size = 223120, upload-time = "2025-08-27T12:14:39.82Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7e/dc7931dc2fa4a6e46b2a4fa744a9fe5c548efd70e0ba74f40b39fa4a8c10/rpds_py-0.27.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:ba81d2b56b6d4911ce735aad0a1d4495e808b8ee4dc58715998741a26874e7c2", size = 358944, upload-time = "2025-08-27T12:14:41.199Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/22/4af76ac4e9f336bfb1a5f240d18a33c6b2fcaadb7472ac7680576512b49a/rpds_py-0.27.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:84f7d509870098de0e864cad0102711c1e24e9b1a50ee713b65928adb22269e4", size = 342283, upload-time = "2025-08-27T12:14:42.699Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/15/2a7c619b3c2272ea9feb9ade67a45c40b3eeb500d503ad4c28c395dc51b4/rpds_py-0.27.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a9e960fc78fecd1100539f14132425e1d5fe44ecb9239f8f27f079962021523e", size = 380320, upload-time = "2025-08-27T12:14:44.157Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/7d/4c6d243ba4a3057e994bb5bedd01b5c963c12fe38dde707a52acdb3849e7/rpds_py-0.27.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:62f85b665cedab1a503747617393573995dac4600ff51869d69ad2f39eb5e817", size = 391760, upload-time = "2025-08-27T12:14:45.845Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/71/b19401a909b83bcd67f90221330bc1ef11bc486fe4e04c24388d28a618ae/rpds_py-0.27.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fed467af29776f6556250c9ed85ea5a4dd121ab56a5f8b206e3e7a4c551e48ec", size = 522476, upload-time = "2025-08-27T12:14:47.364Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/44/1a3b9715c0455d2e2f0f6df5ee6d6f5afdc423d0773a8a682ed2b43c566c/rpds_py-0.27.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f2729615f9d430af0ae6b36cf042cb55c0936408d543fb691e1a9e36648fd35a", size = 403418, upload-time = "2025-08-27T12:14:49.991Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/4b/fb6c4f14984eb56673bc868a66536f53417ddb13ed44b391998100a06a96/rpds_py-0.27.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1b207d881a9aef7ba753d69c123a35d96ca7cb808056998f6b9e8747321f03b8", size = 384771, upload-time = "2025-08-27T12:14:52.159Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/56/d5265d2d28b7420d7b4d4d85cad8ef891760f5135102e60d5c970b976e41/rpds_py-0.27.1-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:639fd5efec029f99b79ae47e5d7e00ad8a773da899b6309f6786ecaf22948c48", size = 400022, upload-time = "2025-08-27T12:14:53.859Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/e9/9f5fc70164a569bdd6ed9046486c3568d6926e3a49bdefeeccfb18655875/rpds_py-0.27.1-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fecc80cb2a90e28af8a9b366edacf33d7a91cbfe4c2c4544ea1246e949cfebeb", size = 416787, upload-time = "2025-08-27T12:14:55.673Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/64/56dd03430ba491db943a81dcdef115a985aac5f44f565cd39a00c766d45c/rpds_py-0.27.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:42a89282d711711d0a62d6f57d81aa43a1368686c45bc1c46b7f079d55692734", size = 557538, upload-time = "2025-08-27T12:14:57.245Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/36/92cc885a3129993b1d963a2a42ecf64e6a8e129d2c7cc980dbeba84e55fb/rpds_py-0.27.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:cf9931f14223de59551ab9d38ed18d92f14f055a5f78c1d8ad6493f735021bbb", size = 588512, upload-time = "2025-08-27T12:14:58.728Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/10/6b283707780a81919f71625351182b4f98932ac89a09023cb61865136244/rpds_py-0.27.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f39f58a27cc6e59f432b568ed8429c7e1641324fbe38131de852cd77b2d534b0", size = 555813, upload-time = "2025-08-27T12:15:00.334Z" },
+    { url = "https://files.pythonhosted.org/packages/04/2e/30b5ea18c01379da6272a92825dd7e53dc9d15c88a19e97932d35d430ef7/rpds_py-0.27.1-cp314-cp314t-win32.whl", hash = "sha256:d5fa0ee122dc09e23607a28e6d7b150da16c662e66409bbe85230e4c85bb528a", size = 217385, upload-time = "2025-08-27T12:15:01.937Z" },
+    { url = "https://files.pythonhosted.org/packages/32/7d/97119da51cb1dd3f2f3c0805f155a3aa4a95fa44fe7d78ae15e69edf4f34/rpds_py-0.27.1-cp314-cp314t-win_amd64.whl", hash = "sha256:6567d2bb951e21232c2f660c24cf3470bb96de56cdcb3f071a83feeaff8a2772", size = 230097, upload-time = "2025-08-27T12:15:03.961Z" },
 ]
 
 [[package]]
@@ -605,6 +753,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/73/e6/03b882225a1b0627e75339b420883dc3c90707a8917d2284abef7a58d317/ruff-0.14.0-py3-none-win32.whl", hash = "sha256:7450a243d7125d1c032cb4b93d9625dea46c8c42b4f06c6b709baac168e10543", size = 12367872, upload-time = "2025-10-07T18:21:46.67Z" },
     { url = "https://files.pythonhosted.org/packages/41/77/56cf9cf01ea0bfcc662de72540812e5ba8e9563f33ef3d37ab2174892c47/ruff-0.14.0-py3-none-win_amd64.whl", hash = "sha256:ea95da28cd874c4d9c922b39381cbd69cb7e7b49c21b8152b014bd4f52acddc2", size = 13464628, upload-time = "2025-10-07T18:21:50.318Z" },
     { url = "https://files.pythonhosted.org/packages/c6/2a/65880dfd0e13f7f13a775998f34703674a4554906167dce02daf7865b954/ruff-0.14.0-py3-none-win_arm64.whl", hash = "sha256:f42c9495f5c13ff841b1da4cb3c2a42075409592825dada7c5885c2c844ac730", size = 12565142, upload-time = "2025-10-07T18:21:53.577Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "80.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/5d/3bf57dcd21979b887f014ea83c24ae194cfcd12b9e0fda66b957c69d1fca/setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c", size = 1319958, upload-time = "2025-05-27T00:56:51.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922", size = 1201486, upload-time = "2025-05-27T00:56:49.664Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add focused unit tests for core configuration, message models, and FastAPI module utilities to raise coverage on core paths
- add OpenAPI contract validation and end-to-end manager/text integration tests plus stabilize the telegram shim for pytest
- wire in jsonschema/coverage-badge dependencies, expose a coverage badge workflow, and publish the generated SVG in docs

## Testing
- uv run pytest
- uv run coverage-badge -o docs/assets/coverage.svg -f


------
https://chatgpt.com/codex/tasks/task_e_68e6515343208323b0abad064d1d4712